### PR TITLE
Fully repopulate edit pages if ModelState is invalid

### DIFF
--- a/src/Enfo.Domain/Entities/EnforcementOrder.cs
+++ b/src/Enfo.Domain/Entities/EnforcementOrder.cs
@@ -1,4 +1,4 @@
-﻿using Enfo.Domain.Entities.Base;
+using Enfo.Domain.Entities.Base;
 using Enfo.Domain.Resources.EnforcementOrder;
 using Enfo.Domain.Utils;
 
@@ -154,7 +154,7 @@ public class EnforcementOrder : BaseEntity
 
         Cause = Guard.NotNullOrWhiteSpace(resource.Cause, nameof(resource.Cause));
         CommentContactId = IsProposedOrder ? resource.CommentContactId : null;
-        CommentPeriodClosesDate = IsProposedOrder ? resource.HearingCommentPeriodClosesDate : null;
+        CommentPeriodClosesDate = IsProposedOrder ? resource.CommentPeriodClosesDate : null;
         County = Guard.NotNullOrWhiteSpace(resource.County, nameof(resource.County));
         ExecutedDate = resource.IsExecutedOrder ? resource.ExecutedDate : null;
         ExecutedOrderPostedDate = resource.IsExecutedOrder ? resource.ExecutedOrderPostedDate : null;

--- a/src/Enfo.WebApp/Pages/Admin/Edit.cshtml
+++ b/src/Enfo.WebApp/Pages/Admin/Edit.cshtml
@@ -92,17 +92,19 @@
             {
                 @Html.EditorFor(m => m.Item.IsExecutedOrder)
                 <label asp-for="Item.IsExecutedOrder"></label>
+                <div id="executed-details">
+                    <label asp-for="Item.ExecutedDate"></label>
+                    <input type="datetime" asp-for="Item.ExecutedDate" class="date-picker usa-input-medium executed-item" />
+                    <span asp-validation-for="Item.ExecutedDate" class="usa-input-error-message"></span>
+                </div>
             }
             else
             {
                 @Html.HiddenFor(m => m.Item.IsExecutedOrder)
-            }
-
-            <div id="executed-details">
                 <label asp-for="Item.ExecutedDate"></label>
                 <input type="datetime" asp-for="Item.ExecutedDate" class="date-picker usa-input-medium executed-item" />
                 <span asp-validation-for="Item.ExecutedDate" class="usa-input-error-message"></span>
-            </div>
+            }
         </fieldset>
 
         <fieldset>

--- a/src/Enfo.WebApp/Pages/Admin/Edit.cshtml.cs
+++ b/src/Enfo.WebApp/Pages/Admin/Edit.cshtml.cs
@@ -92,6 +92,7 @@ namespace Enfo.WebApp.Pages.Admin
                 ModelState.AddModelError(string.Concat(nameof(Item), ".", key), value);
             }
 
+            await PopulateSelectListsAsync();
             return Page();
         }
 

--- a/src/Enfo.WebApp/Pages/Admin/Users/Edit.cshtml.cs
+++ b/src/Enfo.WebApp/Pages/Admin/Users/Edit.cshtml.cs
@@ -43,7 +43,7 @@ namespace Enfo.WebApp.Pages.Admin.Users
         [UsedImplicitly]
         public async Task<IActionResult> OnPostAsync()
         {
-            if (ModelState.IsValid)
+            if (!ModelState.IsValid)
             {
                 DisplayUser = await _userService.GetUserByIdAsync(UserId);
                 if (DisplayUser == null) return NotFound();

--- a/src/Enfo.WebApp/Pages/Admin/Users/Edit.cshtml.cs
+++ b/src/Enfo.WebApp/Pages/Admin/Users/Edit.cshtml.cs
@@ -43,7 +43,13 @@ namespace Enfo.WebApp.Pages.Admin.Users
         [UsedImplicitly]
         public async Task<IActionResult> OnPostAsync()
         {
-            if (!ModelState.IsValid) return Page();
+            if (ModelState.IsValid)
+            {
+                DisplayUser = await _userService.GetUserByIdAsync(UserId);
+                if (DisplayUser == null) return NotFound();
+                await PopulateRoleSettingsAsync();
+                return Page();
+            }
 
             var roleUpdates = UserRoleSettings.ToDictionary(r => r.Name, r => r.IsSelected);
             var result = await _userService.UpdateUserRolesAsync(UserId, roleUpdates);
@@ -54,12 +60,11 @@ namespace Enfo.WebApp.Pages.Admin.Users
                 return RedirectToPage("Details", new {id = UserId});
             }
 
-            DisplayUser = await _userService.GetUserByIdAsync(UserId);
-            if (DisplayUser == null) return NotFound();
-
             foreach (var err in result.Errors)
                 ModelState.AddModelError(string.Empty, string.Concat(err.Code, ": ", err.Description));
 
+            DisplayUser = await _userService.GetUserByIdAsync(UserId);
+            if (DisplayUser == null) return NotFound();
             await PopulateRoleSettingsAsync();
             return Page();
         }

--- a/tests/EnfoTests.WebApp/Pages/Admin/Users/UserEditTests.cs
+++ b/tests/EnfoTests.WebApp/Pages/Admin/Users/UserEditTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Enfo.Domain.Entities.Users;
+﻿using Enfo.Domain.Entities.Users;
 using Enfo.Domain.Resources.Users;
 using Enfo.Domain.Services;
 using Enfo.WebApp.Models;
@@ -14,168 +11,175 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
 
-namespace EnfoTests.WebApp.Pages.Admin.Users
+namespace EnfoTests.WebApp.Pages.Admin.Users;
+
+public class UserEditTests
 {
-    public class UserEditTests
+    private readonly List<Edit.UserRoleSetting> _roleSettings = new()
     {
-        private readonly List<Edit.UserRoleSetting> _roleSettings = new()
+        new Edit.UserRoleSetting
         {
-            new Edit.UserRoleSetting
-            {
-                Name = UserRole.OrderAdministrator,
-                Description = UserRole.OrderAdministratorRole.Description,
-                DisplayName = UserRole.OrderAdministratorRole.DisplayName,
-                IsSelected = true
-            },
-            new Edit.UserRoleSetting
-            {
-                Name = UserRole.SiteMaintenance,
-                Description = UserRole.SiteMaintenanceRole.Description,
-                DisplayName = UserRole.SiteMaintenanceRole.DisplayName,
-                IsSelected = false
-            },
-            new Edit.UserRoleSetting
-            {
-                Name = UserRole.UserMaintenance,
-                Description = UserRole.UserMaintenanceRole.Description,
-                DisplayName = UserRole.UserMaintenanceRole.DisplayName,
-                IsSelected = false
-            },
+            Name = UserRole.OrderAdministrator,
+            Description = UserRole.OrderAdministratorRole.Description,
+            DisplayName = UserRole.OrderAdministratorRole.DisplayName,
+            IsSelected = true
+        },
+        new Edit.UserRoleSetting
+        {
+            Name = UserRole.SiteMaintenance,
+            Description = UserRole.SiteMaintenanceRole.Description,
+            DisplayName = UserRole.SiteMaintenanceRole.DisplayName,
+            IsSelected = false
+        },
+        new Edit.UserRoleSetting
+        {
+            Name = UserRole.UserMaintenance,
+            Description = UserRole.UserMaintenanceRole.Description,
+            DisplayName = UserRole.UserMaintenanceRole.DisplayName,
+            IsSelected = false
+        },
+    };
+
+    [Fact]
+    public async Task OnGet_WithoutRoles_PopulatesThePageModel()
+    {
+        var userView = new UserView(UserTestData.ApplicationUsers[0]);
+
+        var userService = new Mock<IUserService>();
+        userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(userView);
+        userService.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new List<string>());
+        var pageModel = new Edit(userService.Object);
+
+        var result = await pageModel.OnGetAsync(Guid.Empty);
+
+        result.Should().BeOfType<PageResult>();
+        pageModel.UserId.ShouldEqual(Guid.Empty);
+        pageModel.DisplayUser.ShouldEqual(userView);
+        pageModel.UserRoleSettings.ShouldNotBeEmpty();
+        pageModel.UserRoleSettings.Count.ShouldEqual(3);
+    }
+
+    [Fact]
+    public async Task OnGet_WithRoles_PopulatesThePageModel()
+    {
+        var userView = new UserView(UserTestData.ApplicationUsers[0]);
+        var roles = new List<string> { UserRole.OrderAdministrator };
+
+        var userService = new Mock<IUserService>();
+        userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(userView);
+        userService.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(roles);
+        var pageModel = new Edit(userService.Object);
+
+        var result = await pageModel.OnGetAsync(Guid.Empty);
+
+        result.Should().BeOfType<PageResult>();
+        pageModel.UserId.ShouldEqual(Guid.Empty);
+        pageModel.DisplayUser.ShouldEqual(userView);
+        pageModel.UserRoleSettings.Should().BeEquivalentTo(_roleSettings);
+    }
+
+    [Fact]
+    public async Task OnGet_MissingId_ReturnsNotFound()
+    {
+        var userService = new Mock<IUserService>();
+        var pageModel = new Edit(userService.Object);
+
+        var result = await pageModel.OnGetAsync(null);
+
+        result.Should().BeOfType<NotFoundResult>();
+        pageModel.UserId.ShouldEqual(Guid.Empty);
+        pageModel.DisplayUser.ShouldBeNull();
+        pageModel.UserRoleSettings.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task OnGet_NonexistentId_ReturnsNotFound()
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync((UserView)null);
+        var pageModel = new Edit(userService.Object);
+
+        var result = await pageModel.OnGetAsync(Guid.Empty);
+
+        result.Should().BeOfType<NotFoundResult>();
+        pageModel.UserId.Should().Be(Guid.Empty);
+        pageModel.DisplayUser.ShouldBeNull();
+        pageModel.UserRoleSettings.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task OnPost_GivenSuccess_ReturnsRedirectWithDisplayMessage()
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(l => l.UpdateUserRolesAsync(It.IsAny<Guid>(), It.IsAny<Dictionary<string, bool>>()))
+            .ReturnsAsync(IdentityResult.Success);
+        // Initialize Page TempData
+        var httpContext = new DefaultHttpContext();
+        var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+        var pageModel = new Edit(userService.Object)
+        {
+            TempData = tempData,
+            UserId = Guid.Empty,
+            UserRoleSettings = _roleSettings
         };
 
-        [Fact]
-        public async Task OnGet_WithoutRoles_PopulatesThePageModel()
-        {
-            var userView = new UserView(UserTestData.ApplicationUsers[0]);
+        var result = await pageModel.OnPostAsync();
 
-            var userService = new Mock<IUserService>();
-            userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(userView);
-            userService.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(new List<string>());
-            var pageModel = new Edit(userService.Object);
+        pageModel.ModelState.IsValid.ShouldBeTrue();
+        result.Should().BeOfType<RedirectToPageResult>();
+        ((RedirectToPageResult)result).PageName.ShouldEqual("Details");
+        ((RedirectToPageResult)result).RouteValues!["id"].ShouldEqual(Guid.Empty);
+        var expectedMessage = new DisplayMessage(Context.Success, "User roles successfully updated.");
+        pageModel.TempData?.GetDisplayMessage().Should().BeEquivalentTo(expectedMessage);
+    }
 
-            var result = await pageModel.OnGetAsync(Guid.Empty);
+    [Fact]
+    public async Task OnPost_InvalidModel_ReturnsPageWithInvalidModelState()
+    {
+        var userService = new Mock<IUserService>();
+        userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new UserView(UserTestData.ApplicationUsers[0]));
+        userService.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new List<string>());
 
-            result.Should().BeOfType<PageResult>();
-            pageModel.UserId.ShouldEqual(Guid.Empty);
-            pageModel.DisplayUser.ShouldEqual(userView);
-            pageModel.UserRoleSettings.ShouldNotBeEmpty();
-            pageModel.UserRoleSettings.Count.ShouldEqual(3);
-        }
+        var pageModel = new Edit(userService.Object) { UserRoleSettings = new List<Edit.UserRoleSetting>() };
+        pageModel.ModelState.AddModelError("Error", "Sample error description");
 
-        [Fact]
-        public async Task OnGet_WithRoles_PopulatesThePageModel()
-        {
-            var userView = new UserView(UserTestData.ApplicationUsers[0]);
-            var roles = new List<string> {UserRole.OrderAdministrator};
+        var result = await pageModel.OnPostAsync();
 
-            var userService = new Mock<IUserService>();
-            userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(userView);
-            userService.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(roles);
-            var pageModel = new Edit(userService.Object);
+        result.Should().BeOfType<PageResult>();
+        pageModel.ModelState.IsValid.ShouldBeFalse();
+        pageModel.ModelState["Error"]!.Errors[0].ErrorMessage.Should().Be("Sample error description");
+    }
 
-            var result = await pageModel.OnGetAsync(Guid.Empty);
+    [Fact]
+    public async Task OnPost_UpdateRolesFails_ReturnsPageWithInvalidModelState()
+    {
+        var userView = new UserView(UserTestData.ApplicationUsers[0]);
+        var identityResult = IdentityResult.Failed(new IdentityError { Code = "CODE", Description = "DESCRIPTION" });
 
-            result.Should().BeOfType<PageResult>();
-            pageModel.UserId.ShouldEqual(Guid.Empty);
-            pageModel.DisplayUser.ShouldEqual(userView);
-            pageModel.UserRoleSettings.Should().BeEquivalentTo(_roleSettings);
-        }
+        var userService = new Mock<IUserService> { DefaultValue = DefaultValue.Mock };
+        userService.Setup(l => l.UpdateUserRolesAsync(It.IsAny<Guid>(), It.IsAny<Dictionary<string, bool>>()))
+            .ReturnsAsync(identityResult);
+        userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(userView);
+        var pageModel = new Edit(userService.Object) { UserRoleSettings = _roleSettings };
 
-        [Fact]
-        public async Task OnGet_MissingId_ReturnsNotFound()
-        {
-            var userService = new Mock<IUserService>();
-            var pageModel = new Edit(userService.Object);
+        var result = await pageModel.OnPostAsync();
 
-            var result = await pageModel.OnGetAsync(null);
-
-            result.Should().BeOfType<NotFoundResult>();
-            pageModel.UserId.ShouldEqual(Guid.Empty);
-            pageModel.DisplayUser.ShouldBeNull();
-            pageModel.UserRoleSettings.ShouldBeNull();
-        }
-
-        [Fact]
-        public async Task OnGet_NonexistentId_ReturnsNotFound()
-        {
-            var userService = new Mock<IUserService>();
-            userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync((UserView) null);
-            var pageModel = new Edit(userService.Object);
-
-            var result = await pageModel.OnGetAsync(Guid.Empty);
-
-            result.Should().BeOfType<NotFoundResult>();
-            pageModel.UserId.Should().Be(Guid.Empty);
-            pageModel.DisplayUser.ShouldBeNull();
-            pageModel.UserRoleSettings.ShouldBeNull();
-        }
-
-        [Fact]
-        public async Task OnPost_GivenSuccess_ReturnsRedirectWithDisplayMessage()
-        {
-            var userService = new Mock<IUserService>();
-            userService.Setup(l => l.UpdateUserRolesAsync(It.IsAny<Guid>(), It.IsAny<Dictionary<string, bool>>()))
-                .ReturnsAsync(IdentityResult.Success);
-            // Initialize Page TempData
-            var httpContext = new DefaultHttpContext();
-            var tempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
-            var pageModel = new Edit(userService.Object)
-            {
-                TempData = tempData,
-                UserId = Guid.Empty,
-                UserRoleSettings = _roleSettings
-            };
-
-            var result = await pageModel.OnPostAsync();
-
-            pageModel.ModelState.IsValid.ShouldBeTrue();
-            result.Should().BeOfType<RedirectToPageResult>();
-            ((RedirectToPageResult) result).PageName.ShouldEqual("Details");
-            ((RedirectToPageResult) result).RouteValues["id"].ShouldEqual(Guid.Empty);
-            var expectedMessage = new DisplayMessage(Context.Success, "User roles successfully updated.");
-            pageModel.TempData?.GetDisplayMessage().Should().BeEquivalentTo(expectedMessage);
-        }
-
-        [Fact]
-        public async Task OnPost_InvalidModel_ReturnsPageWithInvalidModelState()
-        {
-            var userService = new Mock<IUserService>();
-            var pageModel = new Edit(userService.Object) {UserRoleSettings = new List<Edit.UserRoleSetting>()};
-            pageModel.ModelState.AddModelError("Error", "Sample error description");
-
-            var result = await pageModel.OnPostAsync();
-
-            result.Should().BeOfType<PageResult>();
-            pageModel.ModelState.IsValid.ShouldBeFalse();
-            pageModel.ModelState["Error"].Errors[0].ErrorMessage.Should().Be("Sample error description");
-        }
-
-        [Fact]
-        public async Task OnPost_UpdateRolesFails_ReturnsPageWithInvalidModelState()
-        {
-            var userView = new UserView(UserTestData.ApplicationUsers[0]);
-            var identityResult = IdentityResult.Failed(new IdentityError {Code = "CODE", Description = "DESCRIPTION"});
-
-            var userService = new Mock<IUserService> {DefaultValue = DefaultValue.Mock};
-            userService.Setup(l => l.UpdateUserRolesAsync(It.IsAny<Guid>(), It.IsAny<Dictionary<string, bool>>()))
-                .ReturnsAsync(identityResult);
-            userService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(userView);
-            var pageModel = new Edit(userService.Object) {UserRoleSettings = _roleSettings};
-
-            var result = await pageModel.OnPostAsync();
-
-            result.Should().BeOfType<PageResult>();
-            pageModel.ModelState.IsValid.ShouldBeFalse();
-            pageModel.ModelState[string.Empty].Errors[0].ErrorMessage.Should().Be("CODE: DESCRIPTION");
-        }
+        result.Should().BeOfType<PageResult>();
+        pageModel.ModelState.IsValid.ShouldBeFalse();
+        pageModel.ModelState[string.Empty]!.Errors[0].ErrorMessage.Should().Be("CODE: DESCRIPTION");
     }
 }


### PR DESCRIPTION
When the order edit page or user roles edit page are submitted, the page is returned if the ModelState is invalid. But various page properties, for example select lists, were not fully repopulated.