### PR TITLE
Fix HSTS header and add CSP frame ancestors directive

### DIFF
--- a/src/Enfo.WebApp/Platform/SecurityHeaders/SecurityHeaders.cs
+++ b/src/Enfo.WebApp/Platform/SecurityHeaders/SecurityHeaders.cs
@@ -10,7 +10,7 @@ internal static class SecurityHeaders
         policies.AddXssProtectionBlock();
         policies.AddContentTypeOptionsNoSniff();
 #if !DEBUG
-        policies.AddStrictTransportSecurityMaxAge(TimeSpan.FromDays(730).Seconds);
+        policies.AddStrictTransportSecurityMaxAge((int)TimeSpan.FromDays(730).TotalSeconds);
 #endif
         policies.AddReferrerPolicyStrictOriginWhenCrossOrigin();
         policies.RemoveServerHeader();

--- a/src/Enfo.WebApp/Platform/SecurityHeaders/SecurityHeaders.cs
+++ b/src/Enfo.WebApp/Platform/SecurityHeaders/SecurityHeaders.cs
@@ -57,6 +57,7 @@ internal static class SecurityHeaders
         builder.AddFontSrc().Self();
         builder.AddFormAction().Self();
         builder.AddManifestSrc().Self();
+        builder.AddFrameAncestors().None();
         builder.AddReportUri()
             .To($"https://report-to-api.raygun.com/reports-csp?apikey={ApplicationSettings.Raygun.ApiKey}");
         builder.AddCustomDirective("report-to", "raygun");


### PR DESCRIPTION
- HSTS header was broken in previous PR #66. 
- Frame ancestors directive recommended for CSP ([does not fall back to default](https://www.w3.org/TR/CSP2/#directive-frame-ancestors))

Closes #64