### PR TITLE
Fix Admin Search

### DIFF
--- a/src/Enfo.WebApp/Pages/Admin/Search.cshtml
+++ b/src/Enfo.WebApp/Pages/Admin/Search.cshtml
@@ -123,8 +123,8 @@
 
         <fieldset>
             <legend>Attachments</legend>
-            <input asp-for="Spec.WithAttachments" />
-            <label asp-for="Spec.WithAttachments" class="form-check-label"></label>
+            <input type="checkbox" id="Spec_WithAttachments" name="WithAttachments" value="true" checked="@Model.Spec.WithAttachments">
+            <label asp-for="Spec.WithAttachments"></label>
         </fieldset>
 
         <div class="gaepd-buttonrow">


### PR DESCRIPTION
The attachments search checkbox broke the form.

fixes #77 